### PR TITLE
Add CLI and client for Defra Data API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ ARG PORT_DEBUG=8086
 
 FROM --platform=linux/amd64 defradigital/python-development:${PARENT_VERSION} AS development
 
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+USER nonroot
+
 ENV PATH="/home/nonroot/.venv/bin:${PATH}"
 ENV LOG_CONFIG="logging-dev.json"
 
@@ -34,8 +39,8 @@ ENV LOG_CONFIG="logging.json"
 
 USER root
 
-RUN apt update && \
-    apt install -y curl
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
 
 USER nonroot
 

--- a/app/client/__init__.py
+++ b/app/client/__init__.py
@@ -1,0 +1,26 @@
+"""Python client for the ai-defra-search-data API."""
+
+from app.client.client import AsyncDefraDataClient, DefraDataClient
+from app.client.models import (
+    CreateKnowledgeGroupRequest,
+    KnowledgeGroup,
+    KnowledgeSource,
+    KnowledgeSourceInput,
+    KnowledgeVectorResult,
+    QueryResult,
+    Snapshot,
+    SourceType,
+)
+
+__all__ = [
+    "AsyncDefraDataClient",
+    "DefraDataClient",
+    "CreateKnowledgeGroupRequest",
+    "KnowledgeGroup",
+    "KnowledgeSource",
+    "KnowledgeSourceInput",
+    "KnowledgeVectorResult",
+    "QueryResult",
+    "Snapshot",
+    "SourceType",
+]

--- a/app/client/client.py
+++ b/app/client/client.py
@@ -1,0 +1,310 @@
+"""Sync and async HTTP clients for the ai-defra-search-data API."""
+
+from __future__ import annotations
+
+import httpx
+
+from app.client.models import (
+    CreateKnowledgeGroupRequest,
+    KnowledgeGroup,
+    KnowledgeSource,
+    KnowledgeSourceInput,
+    KnowledgeVectorResult,
+    QueryResult,
+    Snapshot,
+    SourceType,
+)
+
+
+def _parse_source(data: dict) -> KnowledgeSource:
+    return KnowledgeSource(
+        source_id=data.get("sourceId", data.get("source_id", "")),
+        name=data["name"],
+        type=SourceType(data["type"]),
+        location=data["location"],
+    )
+
+
+def _parse_group(data: dict) -> KnowledgeGroup:
+    sources_data = data.get("sources", {})
+    sources = (
+        {
+            k: _parse_source(v) if isinstance(v, dict) else v
+            for k, v in sources_data.items()
+        }
+        if isinstance(sources_data, dict)
+        else {}
+    )
+    return KnowledgeGroup(
+        group_id=data.get("groupId", data.get("group_id", "")),
+        title=data.get("title", data.get("name", "")),
+        description=data["description"],
+        owner=data["owner"],
+        created_at=data.get("createdAt", data.get("created_at", "")),
+        updated_at=data.get("updatedAt", data.get("updated_at", "")),
+        sources=sources,
+    )
+
+
+def _parse_snapshot(data: dict) -> Snapshot:
+    return Snapshot(
+        snapshot_id=data.get("snapshotId", data.get("snapshot_id", "")),
+        group_id=data.get("groupId", data.get("group_id", "")),
+        version=data["version"],
+        created_at=data.get("createdAt", data.get("created_at", "")),
+        sources=data.get("sources", []),
+    )
+
+
+def _parse_vector_result(data: dict) -> KnowledgeVectorResult:
+    return KnowledgeVectorResult(
+        content=data["content"],
+        similarity_score=data.get("similarityScore", data.get("similarity_score", 0)),
+        similarity_category=data.get(
+            "similarityCategory", data.get("similarity_category", "")
+        ),
+        created_at=data.get("createdAt", data.get("created_at", "")),
+        name=data["name"],
+        location=data["location"],
+        snapshot_id=data.get("snapshotId", data.get("snapshot_id", "")),
+        source_id=data.get("sourceId", data.get("source_id", "")),
+    )
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    if response.status_code >= 400:
+        try:
+            detail = response.json().get("detail", response.text)
+        except Exception:
+            detail = response.text
+        msg = f"HTTP {response.status_code}: {detail}"
+        raise httpx.HTTPStatusError(
+            msg,
+            request=response.request,
+            response=response,
+        )
+
+
+class DefraDataClient:
+    """Synchronous client for the Defra Data API (knowledge & snapshots)."""
+
+    def __init__(
+        self,
+        base_url: str = "http://data.localhost",
+        timeout: float = 30.0,
+        **httpx_kwargs: object,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.Client(base_url=base_url, timeout=timeout, **httpx_kwargs)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> DefraDataClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # --- Knowledge groups ---
+
+    def list_groups(self) -> list[KnowledgeGroup]:
+        """List all knowledge groups."""
+        r = self._client.get("/knowledge/groups")
+        if r.status_code == 204:
+            return []
+        _raise_for_status(r)
+        return [_parse_group(g) for g in r.json()]
+
+    def get_group(self, group_id: str) -> KnowledgeGroup:
+        """Get a knowledge group by ID."""
+        r = self._client.get(f"/knowledge/groups/{group_id}")
+        _raise_for_status(r)
+        return _parse_group(r.json())
+
+    def create_group(self, req: CreateKnowledgeGroupRequest) -> KnowledgeGroup:
+        """Create a new knowledge group."""
+        sources = []
+        for s in req.sources:
+            if isinstance(s, KnowledgeSourceInput):
+                sources.append(
+                    {"name": s.name, "type": s.type.value, "location": s.location}
+                )
+            else:
+                sources.append(
+                    {"name": s["name"], "type": s["type"], "location": s["location"]}
+                )
+        payload = {
+            "name": req.name,
+            "description": req.description,
+            "owner": req.owner,
+            "sources": sources,
+        }
+        r = self._client.post("/knowledge/groups", json=payload)
+        _raise_for_status(r)
+        return _parse_group(r.json())
+
+    def add_source(
+        self,
+        group_id: str,
+        source: KnowledgeSourceInput,
+    ) -> KnowledgeGroup:
+        """Add a source to a knowledge group."""
+        payload = {
+            "name": source.name,
+            "type": source.type.value,
+            "location": source.location,
+        }
+        r = self._client.patch(f"/knowledge/groups/{group_id}/sources", json=payload)
+        _raise_for_status(r)
+        return _parse_group(r.json())
+
+    def ingest_group(self, group_id: str) -> dict:
+        """Trigger ingestion for a knowledge group (async, returns immediately)."""
+        r = self._client.post(f"/knowledge/groups/{group_id}/ingest")
+        _raise_for_status(r)
+        return r.json()
+
+    def list_group_snapshots(self, group_id: str) -> list[Snapshot]:
+        """List all snapshots for a knowledge group."""
+        r = self._client.get(f"/knowledge/groups/{group_id}/snapshots")
+        _raise_for_status(r)
+        data = r.json()
+        if isinstance(data, list):
+            return [_parse_snapshot(s) for s in data]
+        return []
+
+    # --- Snapshots ---
+
+    def get_snapshot(self, snapshot_id: str) -> Snapshot:
+        """Get a snapshot by ID."""
+        r = self._client.get(f"/snapshots/{snapshot_id}")
+        _raise_for_status(r)
+        return _parse_snapshot(r.json())
+
+    def activate_snapshot(self, snapshot_id: str) -> dict:
+        """Activate a snapshot for its knowledge group."""
+        r = self._client.patch(f"/snapshots/{snapshot_id}/activate")
+        _raise_for_status(r)
+        return r.json()
+
+    def query(
+        self,
+        group_id: str,
+        query: str,
+        max_results: int = 5,
+    ) -> QueryResult:
+        """Query a group's active snapshot (vector search)."""
+        payload = {"groupId": group_id, "query": query, "maxResults": max_results}
+        r = self._client.post("/snapshots/query", json=payload)
+        _raise_for_status(r)
+        results = [_parse_vector_result(d) for d in r.json()]
+        return QueryResult(results=results)
+
+
+class AsyncDefraDataClient:
+    """Asynchronous client for the Defra Data API."""
+
+    def __init__(
+        self,
+        base_url: str = "http://data.localhost",
+        timeout: float = 30.0,
+        **httpx_kwargs: object,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=base_url, timeout=timeout, **httpx_kwargs
+        )
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> AsyncDefraDataClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    async def list_groups(self) -> list[KnowledgeGroup]:
+        r = await self._client.get("/knowledge/groups")
+        if r.status_code == 204:
+            return []
+        _raise_for_status(r)
+        return [_parse_group(g) for g in r.json()]
+
+    async def get_group(self, group_id: str) -> KnowledgeGroup:
+        r = await self._client.get(f"/knowledge/groups/{group_id}")
+        _raise_for_status(r)
+        return _parse_group(r.json())
+
+    async def create_group(self, req: CreateKnowledgeGroupRequest) -> KnowledgeGroup:
+        sources = []
+        for s in req.sources:
+            if isinstance(s, KnowledgeSourceInput):
+                sources.append(
+                    {"name": s.name, "type": s.type.value, "location": s.location}
+                )
+            else:
+                sources.append(
+                    {"name": s["name"], "type": s["type"], "location": s["location"]}
+                )
+        payload = {
+            "name": req.name,
+            "description": req.description,
+            "owner": req.owner,
+            "sources": sources,
+        }
+        r = await self._client.post("/knowledge/groups", json=payload)
+        _raise_for_status(r)
+        return _parse_group(r.json())
+
+    async def add_source(
+        self,
+        group_id: str,
+        source: KnowledgeSourceInput,
+    ) -> KnowledgeGroup:
+        payload = {
+            "name": source.name,
+            "type": source.type.value,
+            "location": source.location,
+        }
+        r = await self._client.patch(
+            f"/knowledge/groups/{group_id}/sources", json=payload
+        )
+        _raise_for_status(r)
+        return _parse_group(r.json())
+
+    async def ingest_group(self, group_id: str) -> dict:
+        r = await self._client.post(f"/knowledge/groups/{group_id}/ingest")
+        _raise_for_status(r)
+        return r.json()
+
+    async def list_group_snapshots(self, group_id: str) -> list[Snapshot]:
+        r = await self._client.get(f"/knowledge/groups/{group_id}/snapshots")
+        _raise_for_status(r)
+        data = r.json()
+        if isinstance(data, list):
+            return [_parse_snapshot(s) for s in data]
+        return []
+
+    async def get_snapshot(self, snapshot_id: str) -> Snapshot:
+        r = await self._client.get(f"/snapshots/{snapshot_id}")
+        _raise_for_status(r)
+        return _parse_snapshot(r.json())
+
+    async def activate_snapshot(self, snapshot_id: str) -> dict:
+        r = await self._client.patch(f"/snapshots/{snapshot_id}/activate")
+        _raise_for_status(r)
+        return r.json()
+
+    async def query(
+        self,
+        group_id: str,
+        query: str,
+        max_results: int = 5,
+    ) -> QueryResult:
+        payload = {"groupId": group_id, "query": query, "maxResults": max_results}
+        r = await self._client.post("/snapshots/query", json=payload)
+        _raise_for_status(r)
+        results = [_parse_vector_result(d) for d in r.json()]
+        return QueryResult(results=results)

--- a/app/client/models.py
+++ b/app/client/models.py
@@ -1,0 +1,86 @@
+"""Request/response models for the Defra Data API client."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Union
+
+
+class SourceType(str, Enum):
+    """Type of knowledge source."""
+
+    BLOB = "BLOB"
+    PRECHUNKED_BLOB = "PRECHUNKED_BLOB"
+
+
+@dataclass
+class KnowledgeSource:
+    """A knowledge source within a group."""
+
+    source_id: str
+    name: str
+    type: SourceType
+    location: str
+
+
+@dataclass
+class KnowledgeGroup:
+    """A knowledge group with its sources."""
+
+    group_id: str
+    title: str
+    description: str
+    owner: str
+    created_at: str
+    updated_at: str
+    sources: dict[str, KnowledgeSource]
+
+
+@dataclass
+class CreateKnowledgeGroupRequest:
+    """Request to create a knowledge group."""
+
+    name: str
+    description: str
+    owner: str
+    sources: list[Union["KnowledgeSourceInput", dict]]  # dict: {name, type, location}
+
+
+@dataclass
+class KnowledgeSourceInput:
+    """Input for adding a knowledge source."""
+
+    name: str
+    type: SourceType
+    location: str
+
+
+@dataclass
+class Snapshot:
+    """A snapshot of a knowledge group."""
+
+    snapshot_id: str
+    group_id: str
+    version: int
+    created_at: str
+    sources: list[dict]
+
+
+@dataclass
+class KnowledgeVectorResult:
+    """A single result from a vector search query."""
+
+    content: str
+    similarity_score: float
+    similarity_category: str
+    created_at: str
+    name: str
+    location: str
+    snapshot_id: str
+    source_id: str
+
+
+@dataclass
+class QueryResult:
+    """Container for query results."""
+
+    results: list[KnowledgeVectorResult]

--- a/app/entrypoints/cli.py
+++ b/app/entrypoints/cli.py
@@ -1,0 +1,323 @@
+"""Command-line interface for the Defra Data API (knowledge management)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+import httpx
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from app.client.client import DefraDataClient
+from app.client.models import (
+    CreateKnowledgeGroupRequest,
+    KnowledgeSourceInput,
+    SourceType,
+)
+
+app = typer.Typer(
+    help="Defra Data API CLI — knowledge groups, snapshots, and vector search."
+)
+
+groups_app = typer.Typer(help="Knowledge group commands.")
+app.add_typer(groups_app, name="groups")
+
+snapshots_app = typer.Typer(help="Snapshot commands.")
+app.add_typer(snapshots_app, name="snapshots")
+
+console = Console()
+
+
+def _to_serializable(obj: Any) -> Any:
+    """Convert dataclass/enum to JSON-serializable dict."""
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return {k: _to_serializable(v) for k, v in asdict(obj).items()}
+    if hasattr(obj, "value"):  # Enum
+        return obj.value
+    if isinstance(obj, dict):
+        return {k: _to_serializable(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_serializable(v) for v in obj]
+    return obj
+
+
+class CliContext:
+    def __init__(
+        self,
+        base_url: str = "http://data.localhost",
+        timeout: float = 30.0,
+        json_output: bool = False,
+    ):
+        self.base_url = base_url
+        self.timeout = timeout
+        self.json_output = json_output
+
+    def client(self) -> DefraDataClient:
+        return DefraDataClient(base_url=self.base_url, timeout=self.timeout)
+
+
+@app.callback()
+def cli_callback(
+    ctx: typer.Context,
+    base_url: str = typer.Option(
+        "http://data.localhost",
+        "--base-url",
+        "-u",
+        envvar="DEFRA_DATA_URL",
+        help="API base URL",
+    ),
+    timeout: float = typer.Option(
+        30.0, "--timeout", "-t", help="Request timeout in seconds"
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON"),
+) -> None:
+    ctx.obj = CliContext(base_url=base_url, timeout=timeout, json_output=json_output)
+
+
+# --- Groups ---
+
+
+@groups_app.command("list")
+def groups_list(ctx: typer.Context) -> None:
+    """List all knowledge groups."""
+    cfg: CliContext = ctx.obj
+    with cfg.client() as client:
+        groups = client.list_groups()
+
+    if cfg.json_output:
+        console.print(json.dumps(_to_serializable(groups), indent=2))
+        return
+
+    table = Table(title="Knowledge Groups")
+    table.add_column("group_id", style="cyan")
+    table.add_column("title", style="white")
+    table.add_column("owner", style="green")
+    for g in groups:
+        table.add_row(g.group_id, g.title, g.owner)
+    console.print(table)
+
+
+@groups_app.command("get")
+def groups_get(ctx: typer.Context, group_id: str) -> None:
+    """Get a knowledge group by ID."""
+    cfg: CliContext = ctx.obj
+    with cfg.client() as client:
+        group = client.get_group(group_id)
+
+    if cfg.json_output:
+        console.print(json.dumps(_to_serializable(group), indent=2))
+        return
+
+    sources_str = ", ".join(
+        f"{s.source_id}: {s.name} ({s.type.value})" for s in group.sources.values()
+    )
+    console.print(f"[bold]{group.title}[/bold] ({group.group_id})")
+    console.print(f"  Owner: {group.owner}")
+    console.print(f"  Description: {group.description}")
+    console.print(f"  Sources: {sources_str or 'none'}")
+
+
+@groups_app.command("create")
+def groups_create(
+    ctx: typer.Context,
+    name: str = typer.Option(..., "--name", "-n", help="Group name"),
+    description: str = typer.Option(
+        ..., "--description", "-d", help="Group description"
+    ),
+    owner: str = typer.Option(..., "--owner", "-o", help="Owner identifier"),
+    source: list[str] = typer.Option(
+        [],
+        "--source",
+        "-s",
+        help="Source as name:type:location (repeat for multiple). Type: BLOB or PRECHUNKED_BLOB",
+    ),
+) -> None:
+    """Create a new knowledge group."""
+    sources: list[KnowledgeSourceInput] = []
+    for s in source:
+        parts = s.split(":", 2)
+        if len(parts) != 3:
+            msg = "--source must be name:type:location"
+            raise typer.BadParameter(msg)
+        name_part, type_part, location = parts
+        try:
+            src_type = SourceType(type_part.strip())
+        except ValueError:
+            msg = f"type must be BLOB or PRECHUNKED_BLOB, got {type_part}"
+            raise typer.BadParameter(msg) from None
+        sources.append(
+            KnowledgeSourceInput(
+                name=name_part.strip(), type=src_type, location=location
+            )
+        )
+
+    cfg: CliContext = ctx.obj
+    req = CreateKnowledgeGroupRequest(
+        name=name, description=description, owner=owner, sources=sources
+    )
+    with cfg.client() as client:
+        group = client.create_group(req)
+
+    if cfg.json_output:
+        console.print(json.dumps(_to_serializable(group), indent=2))
+        return
+
+    console.print(f"[green]Created group[/green] {group.group_id}: {group.title}")
+
+
+@groups_app.command("add-source")
+def groups_add_source(
+    ctx: typer.Context,
+    group_id: str = typer.Argument(..., help="Group ID"),
+    name: str = typer.Option(..., "--name", "-n", help="Source name"),
+    type_str: str = typer.Option(..., "--type", "-t", help="BLOB or PRECHUNKED_BLOB"),
+    location: str = typer.Option(
+        ..., "--location", "-l", help="Source location (e.g. s3://...)"
+    ),
+) -> None:
+    """Add a source to a knowledge group."""
+    try:
+        src_type = SourceType(type_str)
+    except ValueError:
+        msg = f"type must be BLOB or PRECHUNKED_BLOB, got {type_str}"
+        raise typer.BadParameter(msg) from None
+    cfg: CliContext = ctx.obj
+    source = KnowledgeSourceInput(name=name, type=src_type, location=location)
+    with cfg.client() as client:
+        group = client.add_source(group_id, source)
+
+    if cfg.json_output:
+        console.print(json.dumps(_to_serializable(group), indent=2))
+        return
+
+    console.print(f"[green]Added source[/green] {name} to group {group_id}")
+
+
+@groups_app.command("ingest")
+def groups_ingest(
+    ctx: typer.Context, group_id: str = typer.Argument(..., help="Group ID")
+) -> None:
+    """Trigger ingestion for a knowledge group."""
+    cfg: CliContext = ctx.obj
+    with cfg.client() as client:
+        result = client.ingest_group(group_id)
+
+    if cfg.json_output:
+        console.print(json.dumps(result, indent=2))
+        return
+
+    console.print(f"[green]Ingestion triggered[/green] for {group_id}")
+    console.print(json.dumps(result, indent=2))
+
+
+@groups_app.command("snapshots")
+def groups_snapshots(
+    ctx: typer.Context,
+    group_id: str = typer.Argument(..., help="Group ID"),
+) -> None:
+    """List snapshots for a knowledge group."""
+    cfg: CliContext = ctx.obj
+    with cfg.client() as client:
+        snapshots = client.list_group_snapshots(group_id)
+
+    if cfg.json_output:
+        console.print(json.dumps(_to_serializable(snapshots), indent=2))
+        return
+
+    table = Table(title=f"Snapshots for {group_id}")
+    table.add_column("snapshot_id", style="cyan")
+    table.add_column("version", style="white")
+    table.add_column("created_at", style="green")
+    for s in snapshots:
+        table.add_row(s.snapshot_id, str(s.version), s.created_at)
+    console.print(table)
+
+
+# --- Snapshots ---
+
+
+@snapshots_app.command("get")
+def snapshots_get(
+    ctx: typer.Context,
+    snapshot_id: str = typer.Argument(..., help="Snapshot ID"),
+) -> None:
+    """Get a snapshot by ID."""
+    cfg: CliContext = ctx.obj
+    with cfg.client() as client:
+        snapshot = client.get_snapshot(snapshot_id)
+
+    if cfg.json_output:
+        console.print(json.dumps(_to_serializable(snapshot), indent=2))
+        return
+
+    console.print(f"[bold]Snapshot[/bold] {snapshot.snapshot_id}")
+    console.print(f"  Group: {snapshot.group_id}")
+    console.print(f"  Version: {snapshot.version}")
+    console.print(f"  Created: {snapshot.created_at}")
+
+
+@snapshots_app.command("activate")
+def snapshots_activate(
+    ctx: typer.Context,
+    snapshot_id: str = typer.Argument(..., help="Snapshot ID"),
+) -> None:
+    """Activate a snapshot for its knowledge group."""
+    cfg: CliContext = ctx.obj
+    with cfg.client() as client:
+        result = client.activate_snapshot(snapshot_id)
+
+    if cfg.json_output:
+        console.print(json.dumps(result, indent=2))
+        return
+
+    console.print(f"[green]Activated[/green] snapshot {snapshot_id}")
+    console.print(json.dumps(result, indent=2))
+
+
+# --- Query ---
+
+
+@app.command()
+def query(
+    ctx: typer.Context,
+    group_id: str = typer.Argument(..., help="Knowledge group ID"),
+    query_text: str = typer.Argument(..., help="Search query"),
+    max_results: int = typer.Option(
+        5, "--max-results", "-n", help="Max results to return"
+    ),
+) -> None:
+    """Query a group's active snapshot (vector search)."""
+    cfg: CliContext = ctx.obj
+    with cfg.client() as client:
+        result = client.query(group_id, query_text, max_results=max_results)
+
+    if cfg.json_output:
+        console.print(json.dumps(_to_serializable(result), indent=2))
+        return
+
+    table = Table(title="Query Results")
+    table.add_column("name", style="cyan")
+    table.add_column("score", style="green")
+    table.add_column("content", style="white", max_width=60, overflow="fold")
+    for r in result.results:
+        table.add_row(
+            r.name,
+            f"{r.similarity_score:.3f}",
+            r.content[:200] + "..." if len(r.content) > 200 else r.content,
+        )
+    console.print(table)
+
+
+def main() -> None:
+    try:
+        app()
+    except httpx.HTTPStatusError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/app/ingestion/models.py
+++ b/app/ingestion/models.py
@@ -32,3 +32,7 @@ class ChunkData:
 
 class NoSourceDataError(Exception):
     """Raised when no source data is found for a given source."""
+
+
+class IngestionAlreadyInProgressError(Exception):
+    """Raised when ingest is already running for a knowledge group."""

--- a/app/knowledge_management/router.py
+++ b/app/knowledge_management/router.py
@@ -2,6 +2,7 @@ import datetime
 
 import fastapi
 
+from app.ingestion import models as ingestion_models
 from app.ingestion import service as ingestion_service
 from app.knowledge_management import api_schemas, dependencies, models
 from app.knowledge_management import service as km_service
@@ -177,6 +178,11 @@ async def ingest_group(
         await ingestion_service.process_group(group)
 
         return {"message": f"Ingestion for knowledge group '{group_id}' has been initiated. Processing {len(group.sources)} sources individually."}
+    except ingestion_models.IngestionAlreadyInProgressError as err:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=str(err),
+        ) from err
     except models.KnowledgeGroupNotFoundError as err:
         raise fastapi.HTTPException(status_code=404, detail=f"Knowledge group with ID '{group_id}' not found") from err
 

--- a/migrator/run-setup.sh
+++ b/migrator/run-setup.sh
@@ -3,7 +3,9 @@
 function runDbMigrations() {
     echo "Migrating up $POSTGRES_DB"
 
-    psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT \
+    psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/postgres \
+        -tAc "SELECT 1 FROM pg_database WHERE datname = '$POSTGRES_DB'" | grep -q 1 || \
+    psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/postgres \
         -c "CREATE DATABASE $POSTGRES_DB"
 
     liquibase --driver=org.postgresql.Driver \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "pydantic-settings==2.9.1",
     "pymongo[aws,encryption,snappy,zstd]==4.13.1",
     "sqlalchemy==2.0.43",
+    "click>=8.0,<8.2",
+    "typer==0.15.1",
     "uvicorn==0.34.3",
 ]
 
@@ -36,6 +38,7 @@ dev = [
 
 [project.scripts]
 ai-defra-search-data = "app.entrypoints.fastapi:main"
+knowledge-cli = "app.entrypoints.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,0 +1,427 @@
+"""Tests for the Defra Data API client library."""
+
+import httpx
+import pytest
+
+from app.client import (
+    AsyncDefraDataClient,
+    CreateKnowledgeGroupRequest,
+    DefraDataClient,
+    KnowledgeSourceInput,
+    SourceType,
+)
+
+
+def _make_handler(responses: dict[str, httpx.Response]):
+    """Build a transport handler that returns responses by method+path key."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        key = f"{request.method} {request.url.path}"
+        if key not in responses:
+            return httpx.Response(404, text=f"Unexpected: {key}")
+        return responses[key]
+
+    return handler
+
+
+# --- Fixtures ---
+
+GROUP_RESPONSE_CAMEL = {
+    "groupId": "kg-123",
+    "title": "Test Group",
+    "description": "A test",
+    "owner": "owner",
+    "createdAt": "2025-01-01T00:00:00",
+    "updatedAt": "2025-01-01T00:00:00",
+    "sources": {
+        "ks-1": {
+            "sourceId": "ks-1",
+            "name": "doc",
+            "type": "BLOB",
+            "location": "s3://bucket/file.pdf",
+        }
+    },
+}
+
+GROUP_RESPONSE_SNAKE = {
+    "group_id": "kg-456",
+    "title": "Snake Group",
+    "description": "Snake case",
+    "owner": "owner",
+    "created_at": "2025-01-01T00:00:00",
+    "updated_at": "2025-01-01T00:00:00",
+    "sources": {
+        "ks-2": {
+            "source_id": "ks-2",
+            "name": "doc2",
+            "type": "PRECHUNKED_BLOB",
+            "location": "s3://bucket/file2.json",
+        }
+    },
+}
+
+SNAPSHOT_RESPONSE = {
+    "snapshotId": "snap-1",
+    "groupId": "kg-123",
+    "version": 1,
+    "createdAt": "2025-01-01T00:00:00",
+    "sources": [{"source_id": "ks-1"}],
+}
+
+VECTOR_RESULT = {
+    "content": "Some content",
+    "similarityScore": 0.95,
+    "similarityCategory": "very_high",
+    "createdAt": "2025-01-01T00:00:00",
+    "name": "doc",
+    "location": "s3://bucket/file.pdf",
+    "snapshotId": "snap-1",
+    "sourceId": "ks-1",
+}
+
+
+def client_with_transport(handler):
+    transport = httpx.MockTransport(handler)
+    return DefraDataClient(base_url="http://test", transport=transport)
+
+
+def async_client_with_transport(handler):
+    transport = httpx.MockTransport(handler)
+    return AsyncDefraDataClient(base_url="http://test", transport=transport)
+
+
+# --- Sync client tests ---
+
+
+def test_list_groups_empty():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups": httpx.Response(204),
+        }
+    )
+    with client_with_transport(handler) as client:
+        assert client.list_groups() == []
+
+
+def test_list_groups():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups": httpx.Response(200, json=[GROUP_RESPONSE_CAMEL]),
+        }
+    )
+    with client_with_transport(handler) as client:
+        groups = client.list_groups()
+        assert len(groups) == 1
+        assert groups[0].group_id == "kg-123"
+        assert groups[0].title == "Test Group"
+        assert groups[0].sources["ks-1"].source_id == "ks-1"
+        assert groups[0].sources["ks-1"].type == SourceType.BLOB
+
+
+def test_get_group():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups/kg-123": httpx.Response(
+                200, json=GROUP_RESPONSE_CAMEL
+            ),
+        }
+    )
+    with client_with_transport(handler) as client:
+        group = client.get_group("kg-123")
+        assert group.group_id == "kg-123"
+        assert group.title == "Test Group"
+
+
+def test_get_group_parses_snake_case():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups/kg-456": httpx.Response(
+                200, json=GROUP_RESPONSE_SNAKE
+            ),
+        }
+    )
+    with client_with_transport(handler) as client:
+        group = client.get_group("kg-456")
+        assert group.group_id == "kg-456"
+        assert group.sources["ks-2"].type == SourceType.PRECHUNKED_BLOB
+
+
+def test_create_group_with_sources():
+    handler = _make_handler(
+        {
+            "POST /knowledge/groups": httpx.Response(201, json=GROUP_RESPONSE_CAMEL),
+        }
+    )
+    with client_with_transport(handler) as client:
+        req = CreateKnowledgeGroupRequest(
+            name="New",
+            description="Desc",
+            owner="me",
+            sources=[
+                KnowledgeSourceInput(
+                    name="doc", type=SourceType.BLOB, location="s3://bucket/file.pdf"
+                )
+            ],
+        )
+        group = client.create_group(req)
+        assert group.group_id == "kg-123"
+
+
+def test_create_group_with_dict_sources():
+    handler = _make_handler(
+        {
+            "POST /knowledge/groups": httpx.Response(201, json=GROUP_RESPONSE_CAMEL),
+        }
+    )
+    with client_with_transport(handler) as client:
+        req = CreateKnowledgeGroupRequest(
+            name="New",
+            description="Desc",
+            owner="me",
+            sources=[
+                {"name": "doc", "type": "BLOB", "location": "s3://bucket/file.pdf"}
+            ],
+        )
+        group = client.create_group(req)
+        assert group.group_id == "kg-123"
+
+
+def test_add_source():
+    handler = _make_handler(
+        {
+            "PATCH /knowledge/groups/kg-123/sources": httpx.Response(
+                200, json=GROUP_RESPONSE_CAMEL
+            ),
+        }
+    )
+    with client_with_transport(handler) as client:
+        group = client.add_source(
+            "kg-123",
+            KnowledgeSourceInput(name="doc", type=SourceType.BLOB, location="s3://x"),
+        )
+        assert group.group_id == "kg-123"
+
+
+def test_ingest_group():
+    handler = _make_handler(
+        {
+            "POST /knowledge/groups/kg-123/ingest": httpx.Response(
+                202,
+                json={"message": "Ingestion initiated"},
+            ),
+        }
+    )
+    with client_with_transport(handler) as client:
+        result = client.ingest_group("kg-123")
+        assert result["message"] == "Ingestion initiated"
+
+
+def test_list_group_snapshots():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups/kg-123/snapshots": httpx.Response(
+                200, json=[SNAPSHOT_RESPONSE]
+            ),
+        }
+    )
+    with client_with_transport(handler) as client:
+        snapshots = client.list_group_snapshots("kg-123")
+        assert len(snapshots) == 1
+        assert snapshots[0].snapshot_id == "snap-1"
+        assert snapshots[0].group_id == "kg-123"
+        assert snapshots[0].version == 1
+
+
+def test_get_snapshot():
+    handler = _make_handler(
+        {
+            "GET /snapshots/snap-1": httpx.Response(200, json=SNAPSHOT_RESPONSE),
+        }
+    )
+    with client_with_transport(handler) as client:
+        snap = client.get_snapshot("snap-1")
+        assert snap.snapshot_id == "snap-1"
+
+
+def test_activate_snapshot():
+    handler = _make_handler(
+        {
+            "PATCH /snapshots/snap-1/activate": httpx.Response(
+                200,
+                json={"message": "Snapshot activated"},
+            ),
+        }
+    )
+    with client_with_transport(handler) as client:
+        result = client.activate_snapshot("snap-1")
+        assert "activated" in result["message"]
+
+
+def test_query():
+    handler = _make_handler(
+        {
+            "POST /snapshots/query": httpx.Response(200, json=[VECTOR_RESULT]),
+        }
+    )
+    with client_with_transport(handler) as client:
+        result = client.query("kg-123", "search term", max_results=10)
+        assert len(result.results) == 1
+        assert result.results[0].content == "Some content"
+        assert result.results[0].similarity_score == 0.95
+        assert result.results[0].similarity_category == "very_high"
+
+
+def test_query_default_max_results():
+    handler = _make_handler(
+        {
+            "POST /snapshots/query": httpx.Response(200, json=[]),
+        }
+    )
+    with client_with_transport(handler) as client:
+        result = client.query("kg-123", "search")
+        assert result.results == []
+
+
+def test_query_parses_snake_case_vector_result():
+    """Vector results can use snake_case from API."""
+    snake_result = {
+        "content": "content",
+        "similarity_score": 0.8,
+        "similarity_category": "high",
+        "created_at": "2025-01-01T00:00:00",
+        "name": "doc",
+        "location": "s3://x",
+        "snapshot_id": "snap-1",
+        "source_id": "ks-1",
+    }
+    handler = _make_handler(
+        {
+            "POST /snapshots/query": httpx.Response(200, json=[snake_result]),
+        }
+    )
+    with client_with_transport(handler) as client:
+        result = client.query("kg-123", "q")
+        assert result.results[0].similarity_score == 0.8
+        assert result.results[0].similarity_category == "high"
+
+
+def test_http_error_raises():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups/missing": httpx.Response(
+                404,
+                json={"detail": "Not found"},
+            ),
+        }
+    )
+    with client_with_transport(handler) as client:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            client.get_group("missing")
+        assert exc_info.value.response.status_code == 404
+
+
+def test_http_error_no_json_detail():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups/x": httpx.Response(500, text="Internal error"),
+        }
+    )
+    with client_with_transport(handler) as client:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            client.get_group("x")
+        assert "Internal error" in str(exc_info.value)
+
+
+# --- Async client tests ---
+
+
+@pytest.mark.asyncio
+async def test_async_list_groups_empty():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups": httpx.Response(204),
+        }
+    )
+    async with async_client_with_transport(handler) as client:
+        groups = await client.list_groups()
+        assert groups == []
+
+
+@pytest.mark.asyncio
+async def test_async_list_groups():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups": httpx.Response(200, json=[GROUP_RESPONSE_CAMEL]),
+        }
+    )
+    async with async_client_with_transport(handler) as client:
+        groups = await client.list_groups()
+        assert len(groups) == 1
+        assert groups[0].group_id == "kg-123"
+
+
+@pytest.mark.asyncio
+async def test_async_create_group():
+    handler = _make_handler(
+        {
+            "POST /knowledge/groups": httpx.Response(201, json=GROUP_RESPONSE_CAMEL),
+        }
+    )
+    async with async_client_with_transport(handler) as client:
+        req = CreateKnowledgeGroupRequest(
+            name="New",
+            description="Desc",
+            owner="me",
+            sources=[
+                KnowledgeSourceInput(
+                    name="doc", type=SourceType.BLOB, location="s3://x"
+                )
+            ],
+        )
+        group = await client.create_group(req)
+        assert group.group_id == "kg-123"
+
+
+@pytest.mark.asyncio
+async def test_async_query():
+    handler = _make_handler(
+        {
+            "POST /snapshots/query": httpx.Response(200, json=[VECTOR_RESULT]),
+        }
+    )
+    async with async_client_with_transport(handler) as client:
+        result = await client.query("kg-123", "search", max_results=5)
+        assert len(result.results) == 1
+        assert result.results[0].content == "Some content"
+
+
+@pytest.mark.asyncio
+async def test_async_http_error():
+    handler = _make_handler(
+        {
+            "GET /knowledge/groups/x": httpx.Response(
+                404, json={"detail": "Not found"}
+            ),
+        }
+    )
+    async with async_client_with_transport(handler) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_group("x")
+
+
+# --- Context manager ---
+
+
+def test_sync_context_manager():
+    handler = _make_handler({"GET /knowledge/groups": httpx.Response(204)})
+    with client_with_transport(handler) as client:
+        client.list_groups()
+    # client closed without error
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager():
+    handler = _make_handler({"GET /knowledge/groups": httpx.Response(204)})
+    async with async_client_with_transport(handler) as client:
+        await client.list_groups()
+    # client closed without error

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ dependencies = [
     { name = "aws-embedded-metrics" },
     { name = "boto3" },
     { name = "chonkie" },
+    { name = "click" },
     { name = "dnspython" },
     { name = "ecs-logging" },
     { name = "fastapi" },
@@ -22,6 +23,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pymongo", extra = ["aws", "encryption", "snappy", "zstd"] },
     { name = "sqlalchemy" },
+    { name = "typer" },
     { name = "uvicorn" },
 ]
 
@@ -43,6 +45,7 @@ requires-dist = [
     { name = "aws-embedded-metrics", specifier = "==3.3.0" },
     { name = "boto3", specifier = "==1.40.18" },
     { name = "chonkie", specifier = "==1.3.0" },
+    { name = "click", specifier = ">=8.0,<8.2" },
     { name = "dnspython", specifier = "==2.7.0" },
     { name = "ecs-logging", specifier = "==2.2.0" },
     { name = "fastapi", specifier = "==0.115.12" },
@@ -53,6 +56,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.9.1" },
     { name = "pymongo", extras = ["aws", "encryption", "snappy", "zstd"], specifier = "==4.13.1" },
     { name = "sqlalchemy", specifier = "==2.0.43" },
+    { name = "typer", specifier = "==0.15.1" },
     { name = "uvicorn", specifier = "==0.34.3" },
 ]
 
@@ -339,14 +343,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
@@ -698,7 +702,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -709,7 +712,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -1748,6 +1750,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1854,6 +1865,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/dca7b219718afd37a0068f4f2530a727c2b74a8b6e8e0c0080a4c0de4fcd/typer-0.15.1.tar.gz", hash = "sha256:a0588c0a7fa68a1978a069818657778f86abe6ff5ea6abf472f940a08bfe4f0a", size = 99789, upload-time = "2024-12-04T17:44:58.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/cc/0a838ba5ca64dc832aa43f727bd586309846b0ffb2ce52422543e6075e8a/typer-0.15.1-py3-none-any.whl", hash = "sha256:7994fb7b8155b64d3402518560648446072864beefd44aa2dc36972a5972e847", size = 44908, upload-time = "2024-12-04T17:44:57.291Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Added new Python client for the Defra Data API, including synchronous and asynchronous clients.
- Introduced CLI for managing knowledge groups and snapshots.
- Updated README with new usage instructions for the client and CLI.
- Added models for knowledge sources and groups.
- Implemented tests for the new client functionality.