### PR TITLE
add active_snapshot field and delete source endpoint

### DIFF
--- a/app/ingestion/service.py
+++ b/app/ingestion/service.py
@@ -42,9 +42,8 @@ class IngestionService:
             IngestionAlreadyInProgressError: If ingest is already running for this group
         """
         if group.group_id in _ingest_in_progress:
-            raise ingestion_models.IngestionAlreadyInProgressError(
-                f"Ingestion already in progress for group '{group.group_id}'"
-            )
+            msg = f"Ingestion already in progress for group '{group.group_id}'"
+            raise ingestion_models.IngestionAlreadyInProgressError(msg)
         _ingest_in_progress.add(group.group_id)
 
         snapshot = await self.snapshot_service.create_snapshot(group.group_id, group.sources.values())

--- a/app/knowledge_management/api_schemas.py
+++ b/app/knowledge_management/api_schemas.py
@@ -36,3 +36,4 @@ class KnowledgeGroupResponse(BaseModel):
     created_at: str = Field(..., description="The creation date of the knowledge group in ISO format", serialization_alias="createdAt")
     updated_at: str = Field(..., description="The last update date of the knowledge group in ISO format", serialization_alias="updatedAt")
     sources: dict[str, KnowledgeSourceResponse] = Field(..., description="The sources associated with the knowledge group")
+    active_snapshot: str | None = Field(default=None, description="The active snapshot ID for this group", serialization_alias="activeSnapshot")


### PR DESCRIPTION
- Added 'active_snapshot' field to KnowledgeGroupResponse schema to track the active snapshot ID.
- Updated API responses in the knowledge management router to include the new 'active_snapshot' field.
- Implemented a new endpoint to remove sources from knowledge groups